### PR TITLE
skip validating_path in globbing mode

### DIFF
--- a/src/query_files.rs
+++ b/src/query_files.rs
@@ -41,9 +41,10 @@ fn query_files_regex(
   installed: &InstalledPackages,
 ) -> IoResult<()> {
   let mut stdout = stdout().lock();
+  let is_fullpath = pattern.contains('/');
   let mut found = false;
   files::foreach_database(|path| {
-    let plocate = files::Plocate::new(&path, pattern, true, !pattern.contains('/'))?;
+    let plocate = files::Plocate::new(&path, pattern, true, !is_fullpath)?;
     found = output_plocate(
       &mut stdout,
       plocate,
@@ -93,7 +94,7 @@ fn query_files_pattern(
   };
   let mut found = false;
   files::foreach_database(|path| {
-    let plocate = files::Plocate::new(&path, p, false, !pattern.contains('/'))?;
+    let plocate = files::Plocate::new(&path, p, false, !is_fullpath)?;
     found = output_plocate(
       &mut stdout,
       plocate,

--- a/src/query_files.rs
+++ b/src/query_files.rs
@@ -83,10 +83,14 @@ fn query_files_pattern(
     modified_pattern.push_str("*/");
     if let Some(stripped) = pattern.strip_prefix('/') {
       modified_pattern.push_str(stripped);
-      validating_path = Some(stripped);
+      if !is_glob {
+        validating_path = Some(stripped);
+      }
     } else {
       modified_pattern.push_str(pattern);
-      validating_path = Some(pattern);
+      if !is_glob {
+        validating_path = Some(pattern);
+      }
     }
     modified_pattern.as_str()
   } else {


### PR DESCRIPTION
The `validating_path` check never works for glob patterns, so skip it.