### PR TITLE
Fix bug introduced in pull request #4

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -85,16 +85,15 @@ fn main() -> eyre::Result<()> {
       .error(clap::error::ErrorKind::InvalidValue, "update-db can give twice at most")
       .exit();
   }
-  if args.query.is_empty() {
-    Args::command()
-      .error(clap::error::ErrorKind::MissingRequiredArgument, "no query specified")
-      .exit();
-  }
 
   if args.refresh > 0 {
     build::refresh(args.refresh == 2)?;
   } else if args.update_db > 0 {
     build::update_db(args.update_db == 2)?;
+  } else if args.query.is_empty() {
+    Args::command()
+      .error(clap::error::ErrorKind::MissingRequiredArgument, "no query specified")
+      .exit();
   } else if args.list {
     list::list_packages(&args.query, args.quiet)?;
   } else {


### PR DESCRIPTION
Pull request #4 introduced a bug - pacfiles will return an error (no query specified) when you are trying to rebuild the database.

Return an error only if neither `-y/--refresh` nor `--update-db` is provided to solve this problem.